### PR TITLE
Disable MD033/no-inline-html

### DIFF
--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -1,2 +1,2 @@
 ---
-{"default": true, "MD013": null, "MD028": null}
+{"default": true, "MD013": null, "MD028": null, "MD033": null}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
   <summary>Original README of <a href="https://github.com/mriedmann/humhub-docker" target="_blank">mriedmann/humhub-docker</a></summary>
 
   [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e2c25ed0c4ce479aa9a97be05d1d5b20)](https://app.codacy.com/app/mriedmann/humhub-docker?utm_source=github.com&utm_medium=referral&utm_content=mriedmann/humhub-docker&utm_campaign=Badge_Grade_Dashboard) ![Docker Image CI](https://github.com/mriedmann/humhub-docker/workflows/Docker%20Image%20CI/badge.svg) ![Docker Pulls](https://img.shields.io/docker/pulls/mriedmann/humhub) [![Join the chat at https://gitter.im/humhub-docker/community](https://badges.gitter.im/humhub-docker/community.svg)](https://gitter.im/humhub-docker/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
   
 > :warning: **Version Shift**: We lately changed the versions of latest (1.9->1.10) / stable (1.8->1.9) / legacy (1.8). This can lead to an unexpected update when you are using these moving tags. If you do not want to upgrade, use the corresponding version-tags.
 


### PR DESCRIPTION
Since c6121b8 README.md contains HTML elements to collapse the original sections. This is intentionally, so let's teach the linter