### PR TITLE
Shebang fix

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xeo pipefail
 


### PR DESCRIPTION
Not all Linux platforms (e.g. NixOS) have a bash instance linked/ available as `/bin/bash`

For FHS and non-FHS Linux distributions, using `/usr/bin/env` to locate `bash` is the reliable approach