### PR TITLE
Fix crond stderr logging

### DIFF
--- a/base/etc/supervisord.conf.d/crond-log.conf
+++ b/base/etc/supervisord.conf.d/crond-log.conf
@@ -1,0 +1,7 @@
+[program:crond-log]
+command=/bin/supervisord-log.sh tail -f /var/log/crond.log
+autostart = true
+stdout_logfile=/proc/self/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/proc/self/fd/2
+stderr_logfile_maxbytes=0

--- a/base/etc/supervisord.conf.d/crond.conf
+++ b/base/etc/supervisord.conf.d/crond.conf
@@ -1,5 +1,5 @@
-[program:cron]
-command=/bin/supervisord-log.sh crond -f -d 6
+[program:crond]
+command=/bin/supervisord-log.sh crond -f -l 6 -L /var/log/crond.log
 user=root
 autostart=true
 autorestart=true


### PR DESCRIPTION
crond logging to stderr everything breaks logging detection of errors.

While this is still non-optional since now there's no stderr logging (since we're just tailing the logfile), this makes things easier since we now can use logging pattern detection easier.