### PR TITLE
fix: ci: Incorrect curl trace call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh_debug_enabled }}
       - name: Test
-        run: curl 'http://localhost:8080/' --location --fail --silent | grep 'Sign in</button>' -q || ( curl --trace 'http://localhost:8080/' ; exit 1;)
+        run: curl 'http://localhost:8080/' --location --fail --silent | grep 'Sign in</button>' -q || ( curl 'http://localhost:8080/'  --trace - ; exit 1;)
       - name: Test Email
         run: docker-compose exec -T humhub php /var/www/localhost/htdocs/protected/yii test/email 'test@example.com' --interactive=0 \
           | grep 'Message successfully sent!' -q
@@ -180,7 +180,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh_debug_enabled }}
       - name: Test
-        run: curl 'http://localhost:8080/' --location --fail --silent | grep 'Sign in</button>' -q || ( curl --trace 'http://localhost:8080/' ; exit 1;)
+        run:  'http://localhost:8080/' --location --fail --silent | grep 'Sign in</button>' -q || (  'http://localhost:8080/'  --trace - ; exit 1;)
       - name: Test Email
         run: |
           docker-compose exec -T humhub php /var/www/localhost/htdocs/protected/yii test/email 'test@example.com' --interactive=0 \


### PR DESCRIPTION
The `--trace` parameter requires a file, using `-` redirects all outputs to stdout. 

As file parameter was missing, the URL was parsed as the file to store the trace in, resulting in `curl` erroring with `missing URL`.