### PR TITLE
Fix build pipeline

### DIFF
--- a/.github/workflows/update-humhub.yml
+++ b/.github/workflows/update-humhub.yml
@@ -22,15 +22,20 @@ jobs:
         id: update
         run: |
           . ./update.sh
-          { echo "CUR_VERSION=$CUR_VERSION"; echo "NEW_VERSION=$NEW_VERSION"; } >> "$GITHUB_ENV"
+          { echo "CUR_VERSION=$CUR_VERSION"; echo "NEW_VERSION=$NEW_VERSION"; echo "GIT_BRANCH=$GIT_BRANCH"; } >> "$GITHUB_ENV"
       - name: Check git status and log
         run: |
           git status
           git log
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+      - name: Push changes
+        uses: ad-m/github-push-action@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          delete-branch: true
-          title: "Bump HumHub to ${{ env.NEW_VERSION }}"
-          body: "See Release notes at https://github.com/humhub/humhub/releases/tag/v${{ env.NEW_VERSION }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "${{ env.GIT_BRANCH }}"
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "${{ env.GIT_BRANCH }}"
+          destination_branch: "master"
+          pr_title: "Bump HumHub to ${{ env.NEW_VERSION }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/update.sh
+++ b/update.sh
@@ -5,6 +5,7 @@ set -xeo pipefail
 UPDATE_NEEDED=false
 CUR_VERSION=""
 NEW_VERSION=""
+GIT_BRANCH=""
 
 upstream_versions=$(curl -s https://api.github.com/repos/humhub/humhub/releases | jq -r '.[] | select(.prerelease==false) | .name' | sort --version-sort)
 local_versions=$(cat versions.txt) # to avoid problems when writing doing loop
@@ -29,6 +30,12 @@ while IFS= read -r line; do
 done <<< "$local_versions"
 
 if [ $UPDATE_NEEDED = true ]; then
+    GIT_BRANCH="update-$NEW_VERSION"
+    export GIT_BRANCH
+
+    git branch "$GIT_BRANCH" || true
+    git checkout "$GIT_BRANCH"
+
     git add versions.txt
     git commit -m "update from $CUR_VERSION to $NEW_VERSION"
 fi


### PR DESCRIPTION
- Switch back to repo-sync/pull-request Even though it is deprecated, it serves an important function: It triggers a build for every pull request in order to run the tests. Since GitHub has a built-in limitation around triggering Actions from Actions this is not possible to setup using 'peter-evans/create-pull-request' action.

- Ensure build is run on all PRs generated by dependabot.
- Ensure build is run after every commit.
- Ensure build is run on every PR creted by user.